### PR TITLE
Support lower iOS versions

### DIFF
--- a/NetworkLayer.xcodeproj/project.pbxproj
+++ b/NetworkLayer.xcodeproj/project.pbxproj
@@ -509,6 +509,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -537,6 +538,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/NetworkLayer/Network/NetworkRequest/RequestErrors.swift
+++ b/NetworkLayer/Network/NetworkRequest/RequestErrors.swift
@@ -12,6 +12,8 @@ case invalidURL
 case noResponse
 case decode
 case unathorized
+case notFound
+case defaultCase
     var customMessage: String {
         //Add any message you want, this will be displayed to the user as an error message
         switch self {
@@ -19,6 +21,8 @@ case unathorized
         case .invalidURL: return "Invalid URL"
         case .decode: return "Error decoding data"
         case .unathorized: return "Unauthorized"
+        case .notFound: return "Not Found"
+        case .defaultCase: return "Default Case"
         default: return "Unknown error"
         }
     }


### PR DESCRIPTION
### Description
In the previous solution, iOS versions below 15.0 were not supported.

### Proposed change
An extension function to URLSession that supports iOS versions 14.0+ 

### Remaining
- [x] Test the solution with a GET request.
    - I had to make a few modifications in the API folder to match the requirement of this open API [https://api.agify.io?name=bella](https://api.agify.io/?name=bella) to query the name **Bella**
- [x] Test the solution with a POST request.
